### PR TITLE
USP-3757 Use GitHub hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on:
 
 jobs:
   unit-test:
-    runs-on: [ arss-runner-dind ]
+    runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
       - name: Cache Gradle packages
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Test with Gradle
-        run: ./gradlew test
+        run: ./gradlew jibDockerBuild && ./gradlew test
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
         # Restoring these files from a GitHub Actions cache might cause problems for future builds.
@@ -32,14 +32,14 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
   linter:
-    runs-on: [ arss-runner-dind ]
+    runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
       - name: Cache Gradle packages

--- a/src/test/kotlin/com/onepeloton/locust4k/examples/ExampleAppTest.kt
+++ b/src/test/kotlin/com/onepeloton/locust4k/examples/ExampleAppTest.kt
@@ -28,7 +28,7 @@ class ExampleAppTest : TestcontainersBase() {
 
             // when
             LogMessageWaitStrategy()
-                .withRegEx(".* Receive Message producer ZMQ socket closed.*\\s")
+                .withRegEx(".* Shutting down Locust Worker.*\\s")
                 .withStartupTimeout(Duration.ofSeconds(5))
                 .waitUntilReady(locustWorkerExampleContainer)
 
@@ -53,8 +53,6 @@ class ExampleAppTest : TestcontainersBase() {
                     "Stats consumer stopped",
                     "Stats reporter stopped",
                     "Shutting down Locust Worker",
-                    "Closing connection",
-                    "Receive Message producer ZMQ socket closed",
                 ),
             )
         } finally {
@@ -83,7 +81,7 @@ class ExampleAppTest : TestcontainersBase() {
 
             // when
             LogMessageWaitStrategy()
-                .withRegEx(".* Receive Message producer ZMQ socket closed.*\\s")
+                .withRegEx(".* Shutting down Locust Worker.*\\s")
                 .withStartupTimeout(Duration.ofSeconds(5))
                 .waitUntilReady(locustWorkerExampleContainer)
 
@@ -113,8 +111,6 @@ class ExampleAppTest : TestcontainersBase() {
                     "Stats consumer stopped",
                     "Stats reporter stopped",
                     "Shutting down Locust Worker",
-                    "Closing connection",
-                    "Receive Message producer ZMQ socket closed",
                 ),
             )
         } finally {


### PR DESCRIPTION
- Use GitHub hosted runners. Internal runners do not work for public repositories.
- Update unit tests for better stability while reading shutdown logs